### PR TITLE
Resolves 40: compute shading masks for supervised learning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,5 +34,7 @@ target_link_libraries(${SOLARSHADING_TARGET_NAME} INTERFACE Feelpp::feelpp)
 feelpp_add_application(example_shading_masks_surface_mesh SRCS example_shading_masks.cpp DEFS FEELPP_TOP_DIM=2 LINK_LIBRARIES ${SOLARSHADING_TARGET_NAME} TESTS NO_MPI_TEST INSTALL)
 feelpp_add_application(example_shading_masks_volume_mesh SRCS example_shading_masks.cpp DEFS FEELPP_TOP_DIM=3 LINK_LIBRARIES ${SOLARSHADING_TARGET_NAME} TESTS NO_MPI_TEST INSTALL)
 
+feelpp_add_application(shading_mask_ai_dataset SRCS shading_mask_ai_dataset.cpp LINK_LIBRARIES ${SOLARSHADING_TARGET_NAME} INSTALL)
+
 
 feelpp_add_testcase(cases)

--- a/src/cases/aggregatedMarkers/strasbourg_M0_lod0_ai.cfg
+++ b/src/cases/aggregatedMarkers/strasbourg_M0_lod0_ai.cfg
@@ -1,0 +1,5 @@
+directory = strasbourg_aggregatedmarkers_ai_lod0
+
+json-filename = $cfgdir/strasbourg_aggregatedmarkers.json
+
+gmsh.filename=$cfgdir/strasbourg_M0_lod0.msh

--- a/src/cases/aggregatedMarkers/strasbourg_M0_lod1_ai.cfg
+++ b/src/cases/aggregatedMarkers/strasbourg_M0_lod1_ai.cfg
@@ -1,0 +1,5 @@
+directory = strasbourg_aggregatedmarkers_ai_lod1
+
+json-filename = $cfgdir/strasbourg_aggregatedmarkers.json
+
+gmsh.filename=$cfgdir/strasbourg_M0_lod1.msh

--- a/src/shading_mask.hpp
+++ b/src/shading_mask.hpp
@@ -22,14 +22,14 @@ class ShadingMask
                                             entity_range_t<faces_reference_wrapper_t<MeshType>> >::type;
 
     using wrapper_type = elements_reference_wrapper_t<MeshType>;
-                                        
+
     typedef typename matrix_node<double>::type matrix_node_type;
 
 public:
     using value_type = double;
 
     ShadingMask(mesh_ptrtype mesh, nl::json const& specs, int intervalsAzimuth=72, int intervalsAltitude=10 );
-    
+
     // Subdivide the azimuth angles [0,360]° and altitude angles [0,90]° in subsets for easier computation of the shading masks
     void fixAzimuthAltitudeDiscretization(int intervalsAzimuth=72, int intervalsAltitude=10);
 
@@ -60,8 +60,8 @@ public:
     // Save the shading mask table metadata to json
     void saveMetadata();
 
-private:
-    
+protected:
+
     std::map<std::string,std::unique_ptr<BVH<typename tr_mesh_type::element_type>>> M_bvh_tree_vector;
     std::map<std::string,tr_mesh_ptrtype> M_submeshes;
     std::map<int,node_type> M_faces_to_normals;

--- a/src/shading_mask_ai_dataset.cpp
+++ b/src/shading_mask_ai_dataset.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+
+#include <shading_mask_ai_dataset.hpp>
+#include <feel/feelcore/ptreetools.hpp>
+#include <feel/feelcore/utility.hpp>
+#include <feel/feelcore/json.hpp>
+//#include <feel/feelcore/environment.hpp>
+#include <feel/feelfilters/loadmesh.hpp>
+
+using namespace Feel;
+
+int main(int argc, char **argv)
+{
+    using namespace Feel;
+    using mesh_t = Mesh<Simplex<2,1,3>>;
+
+    po::options_description shadingoptions( "Shading mask options" );
+    shadingoptions.add_options()
+        ( "json-filename", po::value<std::string>()->default_value(""), "json file containing the buildings names" )
+        ;
+
+    Feel::Environment env( _argc=argc,
+                           _argv=argv,
+                           _desc=shadingoptions
+                           );
+
+    // Load the json and recover the building names
+    auto jsonfile = removeComments( readFromFile( Environment::expand( soption("json-filename" ) ) ) );
+    std::istringstream astr( jsonfile );
+    json json_buildings = json::parse( astr );
+
+    // Load the mesh
+    tic();
+
+    auto mesh = loadMesh( _mesh = new mesh_t, _update=MESH_UPDATE_ELEMENTS_ADJACENCY|MESH_NO_UPDATE_MEASURES|MESH_GEOMAP_NOT_CACHED );
+
+    toc("Mesh loaded");
+
+    // Compute the shading masks
+    ShadingMaskAIdataset<mesh_t> sm(mesh,json_buildings);
+    sm.computeMasks();
+
+    std::cout << fmt::format("End Shading mask example\n");
+    return 0;
+}

--- a/src/shading_mask_ai_dataset.hpp
+++ b/src/shading_mask_ai_dataset.hpp
@@ -1,0 +1,478 @@
+#include<shading_mask.hpp>
+
+namespace Feel {
+
+template <typename MeshType>
+class ShadingMaskAIdataset: public ShadingMask<MeshType>
+{
+    using mesh_type = MeshType;
+    typedef typename MeshType::ptrtype mesh_ptrtype;
+
+public:
+
+ShadingMaskAIdataset(mesh_ptrtype mesh, nl::json const& specs, int intervalsAzimuth=72, int intervalsAltitude=10):
+ShadingMask<MeshType>(mesh, specs, intervalsAzimuth, intervalsAltitude)
+{
+    // Create the folder structure for the dataset of modified shading masks in absence of one building
+    // modShadingMasks/missingBuilding/modifiedShadingMask.csv
+    std::string shadingMaskFolder = (boost::filesystem::path(Environment::appRepository())/("modShadingMasks")).string();
+    if (!boost::filesystem::exists(shadingMaskFolder))
+        boost::filesystem::create_directory(shadingMaskFolder);
+    for(auto face : this->M_rangeFaces)
+    {
+        auto f = boost::unwrap_ref( face );
+        std::vector<std::string> composite_marker; // collects all necessary marker substrings to compose the face marker using buildingId and faceId
+        for( auto m : f.marker() )
+        {
+            auto markerName = mesh->markerName(m);
+            if((markerName.find("buildingId_") != std::string::npos))
+            {
+                auto pos = markerName.find_last_of('_');
+                // insert the building name at the beginning of the vector
+                auto buildingId = markerName.substr(pos+1);
+                std::string missingBuildingFolder = shadingMaskFolder+"/"+buildingId;
+                if (!boost::filesystem::exists(missingBuildingFolder))
+                    boost::filesystem::create_directory(missingBuildingFolder);
+            }
+
+        }
+    }
+
+}
+
+void computeMasks();
+
+void saveShadingMaskLocalModifications(const Eigen::Ref<const Eigen::MatrixXd>& M, std::string const& building_id, std::string const& mask_name);
+
+std::map< std::string, std::map< std::string,std::vector<double> > > M_building_modified_masks; // buildingN:{ name_modified_mask_buildingM: modifiedMaskMatrix}
+};
+
+
+template <typename MeshType>
+void
+ShadingMaskAIdataset<MeshType>::computeMasks()
+{
+    if( this->j_["/Buildings"_json_pointer].contains("fileFaces") || this->j_["/Buildings"_json_pointer].contains("aggregatedMarkers") ) // a csv containing the face markers is provided, or they are computed using aggregated markers
+    {
+        std::vector<double> random_direction(3);
+
+        std::map<std::string, int> markerLineMap;
+
+        int matrixSize = this->M_azimuthSize * this->M_altitudeSize;
+
+        // Store large vectors containing all the shading mask matrices whose columns are stacked onto each other
+        std::vector<double> SM_tables(this->M_listFaceMarkers.size() * matrixSize,0);
+        std::vector<double> Angle_tables(this->M_listFaceMarkers.size() * matrixSize,0);
+
+        std::cout << "Allocated SM_tables and Angle_tables of size " << this->M_listFaceMarkers.size() * matrixSize << std::endl;
+
+        int markerNumber = 0;
+
+        // Multithread over rays
+        if (this->M_mthreadtype == "ray")
+        {
+            tic();
+            for(auto const &eltWrap : this->M_rangeFaces ) // from each element of the submesh, launch M_Nrays randomly oriented
+            {
+                auto const& el = unwrap_ref( eltWrap );
+
+                auto elMarker = this->M_mapEntityToBuildingFace.at(el.id());
+
+                auto multithreading_over_rays = [&](int n_rays_thread, int id_thread){
+
+                        Eigen::VectorXd SM_vector(matrixSize);
+                        Eigen::VectorXd Angle_vector(matrixSize);
+
+                        SM_vector.setZero();
+                        Angle_vector.setZero();
+
+                        int index_altitude;
+                        int index_azimuth;
+
+                        int initial_index_rays = n_rays_thread * id_thread ;
+                        for(int j=0;j<n_rays_thread;j++)
+                        {
+
+                            // Construct the ray emitting from a random point of the element
+                            auto random_origin = this->get_random_point(el.vertices());
+
+                            Eigen::VectorXd rand_dir(3);
+                            Eigen::VectorXd p1(3),p2(3),p3(3),origin(3);
+                            bool inward_ray=false;
+
+                            for(int i=0;i<3;i++)
+                            {
+                                p1(i)=column(el.vertices(), 0)[i];
+                                p2(i)=column(el.vertices(), 1)[i];
+                                p3(i)=column(el.vertices(), 2)[i];
+                                origin(i) = random_origin[i];
+                            }
+                            auto element_normal = ((p3-p1).head<3>()).cross((p2-p1).head<3>());
+                            element_normal.normalize();
+
+                            random_direction = std::get<0>(this->M_raysdirections[initial_index_rays + j]);
+                            index_azimuth = std::get<1>(this->M_raysdirections[initial_index_rays + j]);
+                            index_altitude = std::get<2>(this->M_raysdirections[initial_index_rays + j]);
+                            for(int i=0;i<3;i++)
+                            {
+                                rand_dir(i) = random_direction[i];
+                            }
+                            if(rand_dir.dot(element_normal)>=0)
+                            {
+                                inward_ray=true;
+                            }
+
+                            BVHRay<mesh_type::nRealDim> ray( origin, rand_dir, 1e-8 );
+
+                            int closer_intersection_element = -1;
+                            if(inward_ray)
+                            {
+                                closer_intersection_element = 1;
+                            }
+                            else
+                            {
+                                auto rayIntersectionResult =  this->M_bvh->intersect(ray) ;
+                                if ( !rayIntersectionResult.empty() )
+                                    closer_intersection_element = 1;
+                            }
+                            // Compute the index associated to the entry to modify
+                            // The vector is constituted of M_altitudeSize blocks of M_azimuthSize stacked onto each other
+                            int vector_entry = index_azimuth + this->M_azimuthSize*index_altitude;
+
+                            // If there is an intersection, increase the shading mask table entry by 1 and augment the angle table by 1 as well
+                            if ( closer_intersection_element >=0 )
+                            {
+                                SM_vector(vector_entry)++;
+                                Angle_vector(vector_entry)++;
+                            }
+                            else
+                            {
+                                Angle_vector(vector_entry)++;
+                            }
+                        }
+                        return std::make_pair(SM_vector,Angle_vector);
+                    };
+
+                // Execute the lambda function on multiple threads using
+                // std::async and std::future to collect the results
+                std::vector<int> n_rays_thread;
+                n_rays_thread.push_back(this->M_Nrays - (this->M_Nthreads-1) * (int)(this->M_Nrays / this->M_Nthreads));
+
+                for(int t= 1; t < this->M_Nthreads; ++t){
+                n_rays_thread.push_back( this->M_Nrays / this->M_Nthreads);
+                }
+
+                // Used to store the future results
+                std::vector< std::future< std::pair<Eigen::VectorXd, Eigen::VectorXd > > > futures;
+
+                for(int t = 0; t < this->M_Nthreads; ++t){
+
+                    // Start a new asynchronous task
+                    futures.emplace_back(std::async(std::launch::async, multithreading_over_rays, n_rays_thread[t], t));
+                }
+
+                if( markerLineMap.find(elMarker) == markerLineMap.end())
+                {
+                    markerLineMap.insert(std::make_pair(elMarker,markerNumber));
+                    markerNumber += 1;
+                }
+                auto initial_index_SM = SM_tables.begin() +  markerLineMap[elMarker] * matrixSize;
+                auto initial_index_Angles = Angle_tables.begin() +  markerLineMap[elMarker] * matrixSize;
+
+                // Add the tables obtained in threads
+                auto SM_tables_subset = Eigen::Map<Eigen::VectorXd>( &(*initial_index_SM), matrixSize);
+                auto Angle_tables_subset = Eigen::Map<Eigen::VectorXd>( &(*initial_index_Angles), matrixSize);
+
+                for( auto& f : futures){
+                    // Wait for the result to be ready
+                    auto two_vectors =  f.get();
+
+                    SM_tables_subset += two_vectors.first;
+                    Angle_tables_subset += two_vectors.second;
+
+                }
+            }
+            auto timeComputation = toc("Shading masks computed using raytracing");
+            this->M_metadataJson["shadingMask"]["Timer"]["MaskComputation"] = timeComputation;
+            this->M_metadataJson["shadingMask"]["Nthreads"] = this->M_Nthreads;
+            this->M_metadataJson["shadingMask"]["NraysPerElement"] = this->M_Nrays;
+        }
+// Multithread over markers
+        if (this->M_mthreadtype == "markers")
+        {
+
+                auto multithreading_over_markers = [&](std::vector<std::string> marker_list_thread, int id_thread, int start_index){
+
+                        int index_altitude;
+                        int index_azimuth;
+
+                        int initial_index_marker;
+                        int i_marker = 0;
+
+                        int len_marker_list_thread = marker_list_thread.size();
+
+                        std::map< std::string, std::map< std::string,std::vector<double> > > local_building_modified_masks;
+
+                        int vector_entry;
+
+                        for( auto const& marker : marker_list_thread)
+                        {
+                            auto faces_with_marker = this->M_listMarkerFaceEntity[marker];
+
+                            initial_index_marker = start_index + i_marker;
+
+                            auto initial_index_SM = SM_tables.begin() +  initial_index_marker * matrixSize;
+                            auto initial_index_Angles = Angle_tables.begin() +  initial_index_marker * matrixSize;
+
+                            // Extract a view from the vectors SM_tables and Angle_tables
+                            auto SM_vector = Eigen::Map<Eigen::VectorXd>( &(*initial_index_SM), matrixSize);
+                            auto Angle_vector = Eigen::Map<Eigen::VectorXd>( &(*initial_index_Angles), matrixSize);
+
+
+                            for(auto const& face : faces_with_marker)
+                            {
+                                for(int j=0;j<this->M_Nrays;j++)
+                                {
+                                    // Construct the ray emitting from a random point of the element
+                                    auto random_origin = this->get_random_point(face.vertices());
+
+                                    Eigen::VectorXd rand_dir(3);
+                                    Eigen::VectorXd p1(3),p2(3),p3(3),origin(3);
+                                    bool inward_ray=false;
+
+                                    for(int i=0;i<3;i++)
+                                    {
+                                        p1(i)=column(face.vertices(), 0)[i];
+                                        p2(i)=column(face.vertices(), 1)[i];
+                                        p3(i)=column(face.vertices(), 2)[i];
+                                        origin(i) = random_origin[i];
+                                    }
+                                    auto element_normal = ((p3-p1).head<3>()).cross((p2-p1).head<3>());
+                                    element_normal.normalize();
+
+                                    // Choose the direction randomly among the latitude and azimuth
+
+                                    random_direction = std::get<0>(this->M_raysdirections[j]);
+                                    index_azimuth = std::get<1>(this->M_raysdirections[j]);
+                                    index_altitude = std::get<2>(this->M_raysdirections[j]);
+                                    for(int i=0;i<3;i++)
+                                    {
+                                        rand_dir(i) = random_direction[i];
+                                    }
+                                    if(rand_dir.dot(element_normal)>=0)
+                                    {
+                                        inward_ray=true;
+                                    }
+
+                                    BVHRay<mesh_type::nRealDim> ray( origin, rand_dir, 1e-8 );
+
+                                    std::string building_number_first_intersection;
+                                    bool more_than_one_intersection;
+
+                                    int closer_intersection_element = -1;
+                                    if(inward_ray)
+                                    {
+                                        closer_intersection_element = 1;
+                                    }
+                                    else
+                                    {
+                                        auto rayIntersectionResult =  this->M_bvh->intersect(ray) ;
+                                        if ( !rayIntersectionResult.empty() )
+                                        {
+                                            closer_intersection_element = 1;
+
+                                            auto intersected_building_face = this->M_mapEntityToBuildingFace[rayIntersectionResult.front().primitive().meshEntity().id()];
+                                            unsigned first = intersected_building_face.find("building_");
+                                            unsigned last = intersected_building_face.find("_face_");
+                                            unsigned beginning_building_id = first + std::string("building_").length();
+                                            building_number_first_intersection = intersected_building_face.substr(beginning_building_id,last-beginning_building_id);
+                                            if(rayIntersectionResult.size()>1)
+                                            {
+                                                more_than_one_intersection=true;
+                                            }
+                                            else
+                                            {
+                                                more_than_one_intersection=false;
+                                            }
+                                        }
+
+                                    }
+                                    // Compute the index associated to the entry to modify
+                                    // The vector is constituted of M_altitudeSize blocks of M_azimuthSize stacked onto each other
+                                    vector_entry = index_azimuth + this->M_azimuthSize*index_altitude;
+
+                                    // If there is an intersection, increase the shading mask table entry by 1 and augment the angle table by 1 as well
+                                    if ( closer_intersection_element >=0 )
+                                    {
+                                        SM_vector(vector_entry)++;
+                                        Angle_vector(vector_entry)++;
+
+
+                                        if(local_building_modified_masks[building_number_first_intersection][marker].size()!=matrixSize)
+                                        {
+                                            local_building_modified_masks[building_number_first_intersection][marker].resize(matrixSize);
+                                        }
+
+                                        // create a negative shading mask table for the building that shades the current surface
+                                        // this way, a new shading mask for the surface is created in the case the aforementioned building were not there
+
+                                        if( !more_than_one_intersection )
+                                        // the ray is not shaded in absence of building "building_number_first_intersection"
+                                        // otherwise the ray is still shaded by another building which is behind "building_number_first_intersection"
+                                        {
+                                            local_building_modified_masks[building_number_first_intersection][marker][vector_entry]--;
+                                        }
+
+                                    }
+                                    else
+                                    {
+                                        Angle_vector(vector_entry)++;
+                                    }
+                                }
+                            }
+                            // Save the partial shading masks only if they are modified
+                            for(auto [building_id,mask_structure] : local_building_modified_masks)
+                            {
+                                for(auto [mask_name,mask_matrix] : mask_structure)
+                                {
+                                    if (mask_name.find(building_id) != std::string::npos)
+                                        continue;
+
+                                    auto initial_index_marker_it = std::find(this->M_listFaceMarkers.begin(),this->M_listFaceMarkers.end(),mask_name);
+
+                                    int initial_index_marker = initial_index_marker_it-this->M_listFaceMarkers.begin();
+
+                                    bool matrix_is_zeros = std::all_of(mask_matrix.begin(), mask_matrix.end(), [](int i) { return i==0; });
+
+                                    if(!matrix_is_zeros)
+                                    {
+                                        // Subtract from the complete mask the influence of each building
+                                        std::transform(mask_matrix.begin(),mask_matrix.end(),SM_vector.begin(),mask_matrix.begin(),std::plus<double>());
+                                        // Divide by the total amount of rays launched in that direction
+                                        std::transform(mask_matrix.begin(),mask_matrix.end(),Angle_vector.begin(),mask_matrix.begin(),std::divides<double>());
+
+                                        auto shadingMatrix = Eigen::Map<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor>>(mask_matrix.data(),this->M_azimuthSize, this->M_altitudeSize);
+                                        saveShadingMaskLocalModifications(shadingMatrix, building_id, mask_name);
+                                    }
+                                }
+                            }
+                            local_building_modified_masks.clear();
+                            i_marker += 1;
+                            // std::cout << "I_marker " << i_marker << " thread number " << id_thread << " marker " << marker << std::endl;
+                        }
+
+                        return true;
+                    };
+                tic();
+                // Store the index of M_listFaceMarkers where each thread will stop its computations
+                std::vector<int> marker_threads_list_length;
+
+                marker_threads_list_length.push_back(this->M_listFaceMarkers.size() - (this->M_Nthreads-1) * (int)(this->M_listFaceMarkers.size() / this->M_Nthreads));
+
+                for(int t= 1; t < this->M_Nthreads; ++t){
+                marker_threads_list_length.push_back( marker_threads_list_length[t-1] + this->M_listFaceMarkers.size() / this->M_Nthreads);
+                }
+
+                int n0 = 0;
+                int t = 0;
+
+                std::cout << "Size of marker list per thread " << marker_threads_list_length << std::endl;
+
+                std::vector<std::vector<std::string>> marker_thread_lists(marker_threads_list_length.size());
+
+                // Store the index of M_listFaceMarkers from where each thread will start its computations
+                std::vector<int> start_index_list(marker_threads_list_length.size());
+                start_index_list[0]=0;
+
+                for(auto n : marker_threads_list_length)
+                {
+                    for(int i=n0; i< n; i++)
+                    {
+                        marker_thread_lists[t].push_back(this->M_listFaceMarkers[i]);
+                    }
+                    n0 = n;
+                    t += 1;
+                    start_index_list[t]=n;
+                }
+
+                // Used to store the future results
+                // need to
+                std::vector< std::future< bool > > futures;
+
+                for(int t= 0; t < this->M_Nthreads; ++t){
+                // Launch in parallel asynchronously
+                futures.emplace_back(std::async(std::launch::async, multithreading_over_markers, marker_thread_lists[t], t, start_index_list[t]));
+                }
+
+                // Collect futures just to allow asynchronous executions
+                for( auto& f : futures){
+                // Wait for the result to be ready
+                auto a =  f.get();
+                }
+                auto timeComputation = toc("Shading masks computed using raytracing");
+                this->M_metadataJson["shadingMask"]["Timer"]["MaskComputation"] = timeComputation;
+                this->M_metadataJson["shadingMask"]["Nthreads"] = this->M_Nthreads;
+                this->M_metadataJson["shadingMask"]["NraysPerElement"] = this->M_Nrays;
+
+        }
+
+        // Divide the shading mask by the corresponding value of the angle table
+        // If an angle combination has not been selected, suppose there is no shadow
+        std::transform(SM_tables.begin(),SM_tables.end(),Angle_tables.begin(),SM_tables.begin(),std::divides<double>());
+
+        // Shading mask value 0 means that the surface is not shadowed, value 1 it is fully shadowed
+        // Save the shading mask table to a csv file
+        if(this->M_saveMasks)
+        {
+            tic();
+            if(this->j_["/Buildings"_json_pointer].contains("fileFaces") )
+            for(int i=0; i< this->M_listFaceMarkers.size(); i++)
+            {
+                std::string building_name = std::to_string(i);
+                std::string marker = std::to_string(i);
+                auto initial_index_SM = SM_tables.begin() +  i * matrixSize;
+                auto shadingMatrix = Eigen::Map<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor>>(&(*initial_index_SM),this->M_azimuthSize, this->M_altitudeSize);
+                this->saveShadingMask(building_name,marker,shadingMatrix.matrix());
+            }
+            else if(this->j_["/Buildings"_json_pointer].contains("aggregatedMarkers") )
+            {
+                for(int i=0; i< this->M_listFaceMarkers.size(); i++)
+                {
+                    std::string building_name = this->M_listFaceMarkers[i];
+                    std::string marker = "";
+                    auto initial_index_SM = SM_tables.begin() +  i * matrixSize;
+                    auto shadingMatrix = Eigen::Map<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor>>(&(*initial_index_SM),this->M_azimuthSize, this->M_altitudeSize);
+                    this->saveShadingMask(building_name,marker,shadingMatrix.matrix());
+                }
+            }
+            auto timeCSVsaving = toc("Mask CSV saved");
+            this->M_metadataJson["shadingMask"]["Timer"]["MaskCSVsaving"] = timeCSVsaving;
+        }
+    }
+}
+
+template <typename MeshType>
+void
+ShadingMaskAIdataset<MeshType>::saveShadingMaskLocalModifications(const Eigen::Ref<const Eigen::MatrixXd>& M, std::string const& building_id, std::string const& mask_name)
+{
+    int i_long=0;
+    int j_alt=0;
+
+    std::string shadingMaskFolder = (boost::filesystem::path(Environment::appRepository())/("modShadingMasks")).string();
+
+    std::ofstream matrix_file;
+    std::string matrix_filename = shadingMaskFolder+"/"+building_id+"/SM_Matrix_"+mask_name+".csv";
+    matrix_file.open(matrix_filename,std::ios_base::out);
+    for(int i=0; i<this->M_azimuthSize; i++)
+    {
+        for(int j=0; j<this->M_altitudeSize-1; j++)
+        {
+            matrix_file << M(i,j) << ",";
+        }
+        matrix_file << M(i,this->M_altitudeSize-1) << "\n";
+    }
+    matrix_file.close();
+
+}
+
+}

--- a/src/shading_mask_compute.hpp
+++ b/src/shading_mask_compute.hpp
@@ -4,7 +4,7 @@ namespace Feel
 
     // Compute shading masks for one building only
     template <typename MeshType>
-    void 
+    void
     ShadingMask<MeshType>::computeMasksOneBuilding(std::string building_name)
     {
         int dim = M_submeshes[building_name]->realDimension();
@@ -63,7 +63,7 @@ namespace Feel
                                 // Choose the direction randomly among the latitude and azimuth
                                 random_direction = std::get<0>(M_raysdirections[initial_index_rays + j]);
                                 index_azimuth = std::get<1>(M_raysdirections[initial_index_rays + j]);
-                                index_altitude = std::get<2>(M_raysdirections[initial_index_rays + j]);                              
+                                index_altitude = std::get<2>(M_raysdirections[initial_index_rays + j]);
                                 for(int i=0;i<dim;i++)
                                 {
                                     rand_dir(i) = random_direction[i];
@@ -149,7 +149,7 @@ namespace Feel
 
     // Compute shading masks for the buildings in the json file
     template <typename MeshType>
-    void 
+    void
     ShadingMask<MeshType>::computeMasks()
     {
         if( j_["/Buildings"_json_pointer].contains("list") ) // the list of volume markers is provided
@@ -195,11 +195,11 @@ namespace Feel
             M_metadataJson["shadingMask"]["Timer"]["MaskComputation"] = timeComputation;
             M_metadataJson["shadingMask"]["Nthreads"] = M_Nthreads;
             M_metadataJson["shadingMask"]["NraysPerElement"] = M_Nrays;
-            
+
         }
         else if( j_["/Buildings"_json_pointer].contains("fileFaces") ||  j_["/Buildings"_json_pointer].contains("aggregatedMarkers") ) // a csv containing the face markers is provided, or they are computed using aggregated markers
-        {            
-            std::vector<double> random_direction(3);            
+        {
+            std::vector<double> random_direction(3);
 
             std::map<std::string, int> markerLineMap;
 
@@ -211,7 +211,7 @@ namespace Feel
 
             std::cout << "Allocated SM_tables and Angle_tables of size " << M_listFaceMarkers.size() * matrixSize << std::endl;
 
-            int markerNumber = 0;   
+            int markerNumber = 0;
 
             // Multithread over rays
             if (M_mthreadtype == "ray")
@@ -227,7 +227,7 @@ namespace Feel
 
                             Eigen::VectorXd SM_vector(matrixSize);
                             Eigen::VectorXd Angle_vector(matrixSize);
-                            
+
                             SM_vector.setZero();
                             Angle_vector.setZero();
 
@@ -244,7 +244,7 @@ namespace Feel
                                 Eigen::VectorXd rand_dir(3);
                                 Eigen::VectorXd p1(3),p2(3),p3(3),origin(3);
                                 bool inward_ray=false;
-                                
+
                                 for(int i=0;i<3;i++)
                                 {
                                     p1(i)=column(el.vertices(), 0)[i];
@@ -254,7 +254,7 @@ namespace Feel
                                 }
                                 auto element_normal = ((p3-p1).head<3>()).cross((p2-p1).head<3>());
                                 element_normal.normalize();
-                                
+
                                 random_direction = std::get<0>(M_raysdirections[initial_index_rays + j]);
                                 index_azimuth = std::get<1>(M_raysdirections[initial_index_rays + j]);
                                 index_altitude = std::get<2>(M_raysdirections[initial_index_rays + j]);
@@ -278,7 +278,7 @@ namespace Feel
                                 {
                                     auto rayIntersectionResult =  M_bvh->intersect(ray) ;
                                     if ( !rayIntersectionResult.empty() )
-                                        closer_intersection_element = 1;                                
+                                        closer_intersection_element = 1;
                                 }
                                 // Compute the index associated to the entry to modify
                                 // The vector is constituted of M_altitudeSize blocks of M_azimuthSize stacked onto each other
@@ -319,7 +319,7 @@ namespace Feel
                     if( markerLineMap.find(elMarker) == markerLineMap.end())
                     {
                         markerLineMap.insert(std::make_pair(elMarker,markerNumber));
-                        markerNumber += 1; 
+                        markerNumber += 1;
                     }
                     auto initial_index_SM = SM_tables.begin() +  markerLineMap[elMarker] * matrixSize;
                     auto initial_index_Angles = Angle_tables.begin() +  markerLineMap[elMarker] * matrixSize;
@@ -327,10 +327,10 @@ namespace Feel
                     // Add the tables obtained in threads
                     auto SM_tables_subset = Eigen::Map<Eigen::VectorXd>( &(*initial_index_SM), matrixSize);
                     auto Angle_tables_subset = Eigen::Map<Eigen::VectorXd>( &(*initial_index_Angles), matrixSize);
-                    
+
                     for( auto& f : futures){
                         // Wait for the result to be ready
-                        auto two_vectors =  f.get();                                    
+                        auto two_vectors =  f.get();
 
                         SM_tables_subset += two_vectors.first;
                         Angle_tables_subset += two_vectors.second;
@@ -345,12 +345,12 @@ namespace Feel
 // Multithread over markers
             else if (M_mthreadtype == "markers")
             {
-                
+
                     auto multithreading_over_markers = [&](std::vector<std::string> marker_list_thread, int id_thread, int start_index){
 
                             int index_altitude;
                             int index_azimuth;
-                            
+
                             int initial_index_marker;
                             int i_marker = 0;
 
@@ -361,7 +361,7 @@ namespace Feel
                             for( auto const& marker : marker_list_thread)
                             {
                                 auto faces_with_marker = M_listMarkerFaceEntity[marker];
-                                
+
                                 initial_index_marker = start_index + i_marker;
 
                                 auto initial_index_SM = SM_tables.begin() +  initial_index_marker * matrixSize;
@@ -382,7 +382,7 @@ namespace Feel
                                         Eigen::VectorXd rand_dir(3);
                                         Eigen::VectorXd p1(3),p2(3),p3(3),origin(3);
                                         bool inward_ray=false;
-                                        
+
                                         for(int i=0;i<3;i++)
                                         {
                                             p1(i)=column(face.vertices(), 0)[i];
@@ -394,7 +394,7 @@ namespace Feel
                                         element_normal.normalize();
 
                                         // Choose the direction randomly among the latitude and azimuth
-                                        
+
                                         random_direction = std::get<0>(M_raysdirections[j]);
                                         index_azimuth = std::get<1>(M_raysdirections[j]);
                                         index_altitude = std::get<2>(M_raysdirections[j]);
@@ -418,7 +418,7 @@ namespace Feel
                                         {
                                             auto rayIntersectionResult =  M_bvh->intersect(ray) ;
                                             if ( !rayIntersectionResult.empty() )
-                                                closer_intersection_element = 1;                                
+                                                closer_intersection_element = 1;
                                         }
                                         // Compute the index associated to the entry to modify
                                         // The vector is constituted of M_altitudeSize blocks of M_azimuthSize stacked onto each other
@@ -458,7 +458,7 @@ namespace Feel
                     std::cout << "Size of marker list per thread " << marker_threads_list_length << std::endl;
 
                     std::vector<std::vector<std::string>> marker_thread_lists(marker_threads_list_length.size());
-                    
+
                     // Store the index of M_listFaceMarkers from where each thread will start its computations
                     std::vector<int> start_index_list(marker_threads_list_length.size());
                     start_index_list[0]=0;
@@ -475,7 +475,7 @@ namespace Feel
                     }
 
                     // Used to store the future results
-                    // need to 
+                    // need to
                     std::vector< std::future< bool > > futures;
 
                     for(int t= 0; t < M_Nthreads; ++t){
@@ -486,18 +486,18 @@ namespace Feel
                     // Collect futures just to allow asynchronous executions
                     for( auto& f : futures){
                     // Wait for the result to be ready
-                    auto a =  f.get();  
+                    auto a =  f.get();
                     }
                     auto timeComputation = toc("Shading masks computed using raytracing");
                     M_metadataJson["shadingMask"]["Timer"]["MaskComputation"] = timeComputation;
                     M_metadataJson["shadingMask"]["Nthreads"] = M_Nthreads;
                     M_metadataJson["shadingMask"]["NraysPerElement"] = M_Nrays;
-                    
+
             }
-            
+
             // Divide the shading mask by the corresponding value of the angle table
             // If an angle combination has not been selected, suppose there is no shadow
-            std::transform(SM_tables.begin(),SM_tables.end(),Angle_tables.begin(),SM_tables.begin(),std::divides<double>());            
+            std::transform(SM_tables.begin(),SM_tables.end(),Angle_tables.begin(),SM_tables.begin(),std::divides<double>());
 
             // Shading mask value 0 means that the surface is not shadowed, value 1 it is fully shadowed
             // Save the shading mask table to a csv file
@@ -510,7 +510,7 @@ namespace Feel
                     std::string building_name = std::to_string(i);
                     std::string marker = std::to_string(i);
                     auto initial_index_SM = SM_tables.begin() +  i * matrixSize;
-                    auto shadingMatrix = Eigen::Map<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor>>(&(*initial_index_SM),M_azimuthSize, M_altitudeSize);                
+                    auto shadingMatrix = Eigen::Map<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor>>(&(*initial_index_SM),M_azimuthSize, M_altitudeSize);
                     saveShadingMask(building_name,marker,shadingMatrix.matrix());
                 }
                 else if(j_["/Buildings"_json_pointer].contains("aggregatedMarkers") )
@@ -520,7 +520,7 @@ namespace Feel
                         std::string building_name = M_listFaceMarkers[i];
                         std::string marker = "";
                         auto initial_index_SM = SM_tables.begin() +  i * matrixSize;
-                        auto shadingMatrix = Eigen::Map<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor>>(&(*initial_index_SM),M_azimuthSize, M_altitudeSize);                
+                        auto shadingMatrix = Eigen::Map<Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor>>(&(*initial_index_SM),M_azimuthSize, M_altitudeSize);
                         saveShadingMask(building_name,marker,shadingMatrix.matrix());
                     }
                 }
@@ -531,7 +531,7 @@ namespace Feel
         auto end_computation = std::chrono::system_clock::now();
         std::time_t end_time = std::chrono::system_clock::to_time_t(end_computation);
         M_metadataJson["shadingMask"]["Timestamp"]["End"] = strtok(std::ctime(&end_time),"\n");
-        saveMetadata();   
+        saveMetadata();
     }
 
 }


### PR DESCRIPTION
These developments were motivated by the need to compute the shading masks of the whole city when a building is removed from the mesh. In particular, this was needed to perform supervised learning with shading mask data.
The application creates different folders in the results directory, each one with the name of the removed building. Only the shading masks whose values have changed when the given building is absent are stored in these folders. The masks corresponding to the whole mesh (all buildings are present) are still computed, and they complete the dataset.

- closes #40 